### PR TITLE
improvement on Cascade enrich

### DIFF
--- a/src/CascadeConfig.cc
+++ b/src/CascadeConfig.cc
@@ -272,7 +272,8 @@ CascadeConfig CascadeConfig::Compute_Assay(double f_assay, double precision,
     double ratio = 1;
     for (it = actual_cascade.stgs_config.begin(); it != actual_cascade.stgs_config.end(); it++){
       std::map<int, StageConfig>::iterator it_real = (*this).stgs_config.find(it->first);
-      double stg_flow_ratio = it->second.feed_flow / it_real->second.feed_flow;
+      double max_stg_flow = it_real->second.n_machines *it_real->second.centrifuge.feed;
+      double stg_flow_ratio = it->second.feed_flow / max_stg_flow;
       if (ratio < stg_flow_ratio){
         ratio = stg_flow_ratio;
       }

--- a/src/CascadeConfig.cc
+++ b/src/CascadeConfig.cc
@@ -280,6 +280,7 @@ CascadeConfig CascadeConfig::Compute_Assay(double f_assay, double precision,
     for (it = actual_cascade.stgs_config.begin(); it != actual_cascade.stgs_config.end(); it++){
       it->second.feed_flow *= 1./ratio;
     }
+    actual_cascade.feed_flow *= 1./ratio; 
     return actual_cascade;
   }
   // Looping to get the equilibrium

--- a/src/CascadeConfig.h
+++ b/src/CascadeConfig.h
@@ -26,7 +26,7 @@ class CascadeConfig {
   void CalcFeedFlows();
   void CalcStageFeatures();
   void DesignCascade(double max_feed, int max_centrifuges);
-  CascadeConfig Compute_Assay(double feed_assay, double precision);
+  CascadeConfig Compute_Assay(double feed_assay, double precision, bool u_cut = false);
 
   double FeedFlow() { return feed_flow; }
   CentrifugeConfig centrifuge;
@@ -45,7 +45,7 @@ class CascadeConfig {
                          CascadeConfig previous_enrichement);
 
   std::map<int, StageConfig> Update_enrichment(CascadeConfig cascade,
-                                               double feed_assay);
+                                               double feed_assay, bool u_cut = false);
 };
 
 }  // namespace mbmore

--- a/src/CascadeConfig.h
+++ b/src/CascadeConfig.h
@@ -16,7 +16,7 @@ void dgesv_(int *n, int *nrhs, double *a, int *lda, int *ipivot, double *b,
 
 class CascadeConfig {
  public:
-  CascadeConfig() { ; }
+  CascadeConfig() ;
   CascadeConfig(CentrifugeConfig centrifuge, double f_assay, double p_assay,
                 double t_assay, double max_feed_flow, int max_centrifuge,
                 double precision = 1e-8);

--- a/src/CascadeConfig.h
+++ b/src/CascadeConfig.h
@@ -20,30 +20,53 @@ class CascadeConfig {
   CascadeConfig(CentrifugeConfig centrifuge, double f_assay, double p_assay,
                 double t_assay, double max_feed_flow, int max_centrifuge,
                 double precision = 1e-8);
+  // Build a full cascade such as all stage follow alpha = beta = const. Get
+  // alpha/beta value from feeding stage. From the design feed/product/assay
   void BuildIdealCascade(double f_assay, double p_assay, double w_assay,
                          double precision = 1e-8);
+  // Get the total number of machine in the Cascade
   int FindTotalMachines();
+
+  // Solve the flow matrix from the stages cuts
   void CalcFeedFlows();
+  // DO something ?!
   void CalcStageFeatures();
+  // Scale the Casacde to meet the limitation in max feed or max centrifuges
   void DesignCascade(double max_feed, int max_centrifuges);
+
+  // Compute the response of the cascade to a non ideal feed assay
   CascadeConfig Compute_Assay(double feed_assay, double precision, bool u_cut = false);
 
   double FeedFlow() { return feed_flow; }
+  // Configuration of the centrifuges in the stages
   CentrifugeConfig centrifuge;
+  // Map of all the stage configuration
   std::map<int, StageConfig> stgs_config;
+  // number of enrich stages
   int n_enrich;
+  // number of stripping stages
   int n_strip;
 
  private:
+  // total number of machine in the Cascade
   int n_machines;
+  // real feed flow (constrained by the cascade design/total number of
+  // machine/max feed flow
   double feed_flow;
-  double feed_assay;
-  double design_product_assay;
-  double design_tail_assay;
 
+  //design feed assay
+  double feed_assay;
+  //design product assay
+  double design_product_assay;
+  //design tail assay
+  double design_tail_assay;
+  
+  // Method to check the assays different between 2 cascades
   double Diff_enrichment(CascadeConfig actual_enrichments,
                          CascadeConfig previous_enrichement);
 
+  // method computing one iteration, of the algorithm used to get the response
+  // to non ideal feed assay 
   std::map<int, StageConfig> Update_enrichment(CascadeConfig cascade,
                                                double feed_assay, bool u_cut = false);
 };

--- a/src/CascadeEnrich.cc
+++ b/src/CascadeEnrich.cc
@@ -70,6 +70,9 @@ void CascadeEnrich::EnterNotify() {
     std::cout << " PA: " << it->second.product_assay;
     std::cout << " TA: " << it->second.tail_assay;
     std::cout << " feed_flow: " << it->second.feed_flow;
+    std::cout << " cut: " << it->second.cut;
+    std::cout << " alpha: " << it->second.alpha;
+    std::cout << " beta: " << it->second.beta;
     std::cout << std::endl;
   }
   if (max_feed_inventory > 0) {

--- a/src/CascadeEnrich.cc
+++ b/src/CascadeEnrich.cc
@@ -30,6 +30,7 @@ CascadeEnrich::CascadeEnrich(cyclus::Context* ctx)
       feed_commod(""),
       product_commod(""),
       tails_commod(""),
+      fix_ab(false),
       order_prefs(true) {}
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CascadeEnrich::~CascadeEnrich() {}
@@ -463,11 +464,11 @@ double CascadeEnrich::FeedAssay(double quantity) {
 }
 
 double CascadeEnrich::ProductAssay(double feed_assay) {
-  CascadeConfig cascade_tmp = cascade.Compute_Assay(feed_assay, precision);
+  CascadeConfig cascade_tmp = cascade.Compute_Assay(feed_assay, precision, fix_ab);
   return cascade_tmp.stgs_config.rbegin()->second.product_assay;
 }
 double CascadeEnrich::TailsAssay(double feed_assay) {
-  CascadeConfig cascade_tmp = cascade.Compute_Assay(feed_assay, precision);
+  CascadeConfig cascade_tmp = cascade.Compute_Assay(feed_assay, precision, fix_ab);
   return cascade_tmp.stgs_config.begin()->second.tail_assay;
 }
 

--- a/src/CascadeEnrich.cc
+++ b/src/CascadeEnrich.cc
@@ -465,10 +465,26 @@ double CascadeEnrich::FeedAssay(double quantity) {
 
 double CascadeEnrich::ProductAssay(double feed_assay) {
   CascadeConfig cascade_tmp = cascade.Compute_Assay(feed_assay, precision, fix_ab);
+  std::cout << "product_assay " << std::setprecision(16) << cascade_tmp.stgs_config.rbegin()->second.product_assay << std::endl;
   return cascade_tmp.stgs_config.rbegin()->second.product_assay;
 }
 double CascadeEnrich::TailsAssay(double feed_assay) {
+  std::cout << "feed_assay " << feed_assay << std::endl;
   CascadeConfig cascade_tmp = cascade.Compute_Assay(feed_assay, precision, fix_ab);
+  std::cout << "tails_assay " << cascade_tmp.stgs_config.begin()->second.tail_assay << std::endl;
+  std::map<int, StageConfig>::iterator it;
+  for (it = cascade_tmp.stgs_config.begin(); it != cascade_tmp.stgs_config.end();
+       it++) {
+    std::cout << "stg " << it->first;
+    std::cout << " FA: " << it->second.feed_assay;
+    std::cout << " PA: " << it->second.product_assay;
+    std::cout << " TA: " << it->second.tail_assay;
+    std::cout << " feed_flow: " << it->second.feed_flow;
+    std::cout << " cut: " << it->second.cut;
+    std::cout << " alpha: " << it->second.alpha;
+    std::cout << " beta: " << it->second.beta;
+    std::cout << std::endl;
+  }
   return cascade_tmp.stgs_config.begin()->second.tail_assay;
 }
 

--- a/src/CascadeEnrich.cc
+++ b/src/CascadeEnrich.cc
@@ -27,6 +27,7 @@ CascadeEnrich::CascadeEnrich(cyclus::Context* ctx)
       machine_feed(15),
       max_enrich(1),
       design_feed_flow(100),
+      L_over_F(2),
       feed_commod(""),
       product_commod(""),
       tails_commod(""),
@@ -57,6 +58,7 @@ void CascadeEnrich::EnterNotify() {
   centrifuge.diameter = diameter;
   centrifuge.feed = machine_feed / 1000 / 1000;
   centrifuge.temp = temp;
+  centrifuge.flow_internal = L_over_F;
 
   cascade = CascadeConfig(centrifuge, design_feed_assay, design_product_assay,
                           design_tails_assay, FlowPerSec(design_feed_flow),
@@ -73,8 +75,10 @@ void CascadeEnrich::EnterNotify() {
     std::cout << " cut: " << it->second.cut;
     std::cout << " alpha: " << it->second.alpha;
     std::cout << " beta: " << it->second.beta;
+    std::cout << " machine: " << it->second.n_machines;
     std::cout << std::endl;
   }
+  std::cout << "Dsign Feed Flow " << FlowPerMon(cascade.FeedFlow()) << std::endl;
   if (max_feed_inventory > 0) {
     inventory.capacity(max_feed_inventory);
   }

--- a/src/CascadeEnrich.h
+++ b/src/CascadeEnrich.h
@@ -177,7 +177,7 @@ class CascadeEnrich : public cyclus::Facility {
 //group all the characteristic of a centrifuges
   CentrifugeConfig centrifuge;
   CascadeConfig cascade;
-  double precision = 1e-8;
+  double precision = 1e-15;
   
   
   const double secpermonth = 60.*60.*24.*(365.25/12.);

--- a/src/CascadeEnrich.h
+++ b/src/CascadeEnrich.h
@@ -292,6 +292,13 @@ class CascadeEnrich : public cyclus::Facility {
   double diameter;
 
 #pragma cyclus var {					  \
+    "default" : 2, \
+    "tooltip" : "Centrifuge L/F* ", \
+    "uilabel" : "Centrifuge Countercurrent to feed ratio", \
+  "doc" : "Countercurrent to feed ratio"}
+  double L_over_F;
+
+#pragma cyclus var {					  \
     "default" : 15.0, \
     "tooltip" : "Centrifuge feed rate (mg/sec)", \
     "uilabel" : "Max feed rate for single centrifuge (mg/sec)", \

--- a/src/CascadeEnrich.h
+++ b/src/CascadeEnrich.h
@@ -192,11 +192,12 @@ class CascadeEnrich : public cyclus::Facility {
   int n_strip_stages;
 
   // Set by maximum allowable centrifuges
-  double max_feed_flow;
   double ProductAssay(double feed_assay);
   double ProductFlow(double feed_flow);
   double TailsAssay(double feed_assay);
   double TailsFlow(double feed_flow);
+  double FeedRequired(double prod_qty);
+  double MaxFeedFlow(double feed_assay);
 
   #pragma cyclus var { \
     "tooltip" : "feed recipe", \

--- a/src/CascadeEnrich.h
+++ b/src/CascadeEnrich.h
@@ -296,6 +296,14 @@ class CascadeEnrich : public cyclus::Facility {
     "uilabel" : "Max feed rate for single centrifuge (mg/sec)", \
   "doc" : "maximum feed rate for a single centrifuge (mg/sec)"}
   double machine_feed;
+  
+#pragma cyclus var { \
+    "default": 0, \
+    "userlevel": 10, \
+    "tooltip": "Fix ALpha Beta recompute Theta", \
+    "uilabel": "recompute theta to maintain alpha and beta", \
+    "doc": "maintain alpha beta constant and recompute the cut for it" }
+  bool fix_ab;
 
 
 

--- a/src/CascadeEnrich_tests.cc
+++ b/src/CascadeEnrich_tests.cc
@@ -177,7 +177,7 @@ TEST_F(CascadeEnrichTest, TradeTails) {
   sim.AddRecipe("natu1", cascadenrichtest::c_natu1());
   sim.AddRecipe("leu", cascadenrichtest::c_leu());
 
-  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSource("natu").recipe("natu1").capacity(200).Finalize();
   sim.AddSink("enr_u").recipe("leu").Finalize();
   sim.AddSink("tails").Finalize();
 
@@ -209,7 +209,7 @@ TEST_F(CascadeEnrichTest, TailsQty) {
   sim.AddRecipe("natu1", cascadenrichtest::c_natu1());
   sim.AddRecipe("leu", cascadenrichtest::c_leu());
 
-  sim.AddSource("natu").recipe("natu1").Finalize();
+  sim.AddSource("natu").recipe("natu1").capacity(200).Finalize();
   sim.AddSink("enr_u").recipe("leu").capacity(0.5).Finalize();
   sim.AddSink("enr_u").recipe("leu").capacity(0.5).Finalize();
   sim.AddSink("tails").Finalize();
@@ -255,6 +255,7 @@ TEST_F(CascadeEnrichTest, BidPrefs) {
   sim.AddRecipe("natu1", cascadenrichtest::c_natu1());
   sim.AddRecipe("natu2", cascadenrichtest::c_natu2());
 
+  sim.AddSource("natu").recipe("natu1").capacity(200).Finalize();
   sim.AddSource("natu").recipe("natu1").capacity(1).Finalize();
 
   sim.AddSource("natu").recipe("natu2").capacity(2).Finalize();

--- a/src/CentrifugeConfig.cc
+++ b/src/CentrifugeConfig.cc
@@ -30,7 +30,7 @@ CentrifugeConfig::CentrifugeConfig() {
 }
 
 CentrifugeConfig::CentrifugeConfig(double v_a_, double h_, double d_, double feed_, double T_,
-                   double eff_, double M_, double dM_, double x_, double i_flow_){
+                   double eff_, double M_, double dM_, double x_, double flow_){
   v_a = v_a_;
   height = h_;
   diameter = d_;
@@ -39,7 +39,7 @@ CentrifugeConfig::CentrifugeConfig(double v_a_, double h_, double d_, double fee
 
   eff = eff_;
   x = x_;
-  flow_internal = i_flow_;
+  flow_internal = flow_;
 
   M = M_;
   dM = dM_;

--- a/src/CentrifugeConfig.h
+++ b/src/CentrifugeConfig.h
@@ -36,6 +36,7 @@ class CentrifugeConfig {
   double M_238;      // kg/mol
   double secpermonth; // obvious ?!
 
+  // two method to compute some part of the solution to the Raetz equation
   double CalcCTherm(double v_a, double temp, double dM);
   double CalcV(double assay);
 };

--- a/src/CentrifugeConfig.h
+++ b/src/CentrifugeConfig.h
@@ -14,27 +14,27 @@ class CentrifugeConfig {
   CentrifugeConfig(double v_a, double h, double d, double feed, double T,
                    double eff, double M, double dM, double x, double i_flow);
 
-  double ComputeDeltaU(double cut);
+  double ComputeDeltaU(double cut); // compute the solution of the Raetz equation using all the paramters valus and the provided cut value
 
   // flow_internal = 2-4, x = pressure ratio, M = 0.352 kg/mol of UF6,
   // dM = 0.003 kg/mol diff between 235 and 238
-  double M;
-  double dM;
-  double x;
-  double flow_internal;
+  double dM; // molar mass diff between the 2 components of the gaz default 0.003kg/mol (u235/U238)
+  double M;  // gaz molar mass, default UF6 0.352 kg/mol
+  double x;  // pressure ration -> drive r1/r2 ratio
+  double flow_internal; // countercurrent-to-feed ratios k range between 2 and 4
 
-  double v_a;
-  double height;
-  double diameter;
-  double feed;
-  double temp;
-  double eff;
+  double v_a; // peripheral velocities
+  double height; // centrifugre height
+  double diameter; // centrifuge diameter
+  double feed; // feed flow rate
+  double temp; // average gaz temperature
+  double eff; // efficiency
 
  private:
   double D_rho;      // kg/m/s
   double gas_const;  // J/K/mol
   double M_238;      // kg/mol
-  double secpermonth;
+  double secpermonth; // obvious ?!
 
   double CalcCTherm(double v_a, double temp, double dM);
   double CalcV(double assay);

--- a/src/StageConfig.cc
+++ b/src/StageConfig.cc
@@ -92,7 +92,7 @@ double StageConfig::BetaByAlphaAndCut() {
   return beta;
 }
 
-double StageConfig::CutByAalphaBeta() {
+double StageConfig::CutByAlphaBeta() {
   double product_assay = ProductAssay();
   double tail_assay = TailAssay();
 
@@ -109,7 +109,7 @@ void StageConfig::BuildIdealStg(double f_assay, double precision) {
     beta = BetaByAlphaAndCut();
   } else {
     beta = alpha;
-    cut = CutByAalphaBeta();
+    cut = CutByAlphaBeta();
   }
   product_assay = ProductAssay();
   tail_assay = TailAssay();

--- a/src/StageConfig.cc
+++ b/src/StageConfig.cc
@@ -106,7 +106,8 @@ void StageConfig::BuildIdealStg(double f_assay, double precision) {
     cut = CutForIdealStg(feed_assay, precision);
     DU = centrifuge.ComputeDeltaU(cut);
     alpha = AlphaByDU();
-    beta = BetaByAlphaAndCut();
+    beta = alpha;
+    cut = CutByAlphaBeta();
   } else {
     beta = alpha;
     cut = CutByAlphaBeta();

--- a/src/StageConfig.h
+++ b/src/StageConfig.h
@@ -14,36 +14,53 @@ class StageConfig {
   StageConfig() {;}
   StageConfig(double f_assay, double feed_flow, double precision, double cut = -1, double DU = -1, double alpha = -1); 
 
+  // Build a stage assumming alpha = beta (if cut is not defined, compute the cut to make it so)
   void BuildIdealStg(double f_assay, double precision = 1e-8);
+  // Compute the cut to ensure alpha = beta (from dU)
   double CutForIdealStg(double f_assay, double precision = 1e-8);
 
+  // calculate Alpha value using the dU, Cut and the centrifuge feed flow value
   double AlphaByDU();
 
+  // Compute Beta value from alpha value, cut and feed assay
   double BetaByAlphaAndCut();
+  // recompute Cut value assuming Alpha and Beta fixed
   double CutByAlphaBeta();
 
+  // COmpute Product assay from feed assay and alpha
   double ProductAssay();
+  // Compute Waste assy from feed assay and beta
   double TailAssay();
 
+  // Return the minimum number of centrifudes required to meed the feed flow
   double MachinesPerStage();
+  // Compute the Product feed 
   double ProductPerEnrStage();
 
-  // Calculates the V(N_x) term for enrichment eqns where N_x is the assay
-  // of isotope x
-
+  // Configuration of all the centrifuges in the stage
   CentrifugeConfig centrifuge;
+  // Precision used for the cut calculation defautl 1e-8
   double precision;
 
+  // cut value of the stage
   double cut;
+  // dU value of the stage (calculted form the centrifuges config with the cut)
   double DU;
+  // Feed to Product enrichment ratio
   double alpha;
+  // Feed to Tail enrichment ratio
   double beta;
+  // Feed flow (g/s)
   double feed_flow;
   
+  // number of centriges in the stage
   double n_machines;
-
+  
+  // Feed assay
   double feed_assay;
+  // Product assay
   double product_assay;
+  // Tail assay
   double tail_assay;
 };
 

--- a/src/StageConfig.h
+++ b/src/StageConfig.h
@@ -20,7 +20,7 @@ class StageConfig {
   double AlphaByDU();
 
   double BetaByAlphaAndCut();
-  double CutByAalphaBeta();
+  double CutByAlphaBeta();
 
   double ProductAssay();
   double TailAssay();


### PR DESCRIPTION
this adds:
- default constructor
- add new method to compute the response to non ideal feed assay (alpha = beta = const)
- increase number of centrifuge parameters modifiable by the user 
- add some doc about the different variables
- fix calculation of the feed required when feed with non ideal assay feed